### PR TITLE
Fixes cmake install.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 project(modelica3d_dbus CXX C)
-option(USE_OMC "use openmodelica" ON)
+option(USE_OMC "use openmodelica" OFF)
 option(OSG_BACKEND "build openscenegraph backed" ON)
 option(INSTALL_EXAMPLES "install examples" ON)
 option(BLENDER_BACKEND "build blender backed" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 project(modelica3d_dbus CXX C)
-option(USE_OMC "use openmodelica" OFF)
+option(USE_OMC "use openmodelica" ON)
 option(OSG_BACKEND "build openscenegraph backed" ON)
 option(INSTALL_EXAMPLES "install examples" ON)
 option(BLENDER_BACKEND "build blender backed" ON)

--- a/common/cmake/FindOMC.cmake
+++ b/common/cmake/FindOMC.cmake
@@ -1,10 +1,10 @@
 # Tries to detect omc modelica-library and include dirs, does not search for binary yet
 
 # This will also search ${CMAKE_PREFIX_PATH}/include automagically
-find_path(OMC_INCLUDE_DIR modelica.h PATH_SUFFIXES omc)
+find_path(OMC_INCLUDE_DIR openmodelica.h PATH_SUFFIXES omc/c)
 
 # This will _not_ search ${CMAKE_PREFIX_PATH}/lib automagically, we need to give a search hint
-find_path(OMC_MOD_LIB_DIR "Modelica 3.1/package.mo" 
+find_path(OMC_MOD_LIB_DIR "ModelicaReference/package.mo"
   PATHS "${CMAKE_LIBRARY_PATH}/omlibrary"
         "${CMAKE_PREFIX_PATH}/lib/omlibrary" /usr/lib/omlibrary)
 

--- a/lib/modbus/CMakeLists.txt
+++ b/lib/modbus/CMakeLists.txt
@@ -15,7 +15,7 @@ if (USE_OMC)
     DESTINATION "${OMC_MOD_LIB_DIR}/${MODELICA_SERVICES_LIBRARY}")
 
   # Install library header
-  #install(FILES "${modbus_src}/c/modbus.h" DESTINATION ${OMC_INCLUDE_DIR})
+  install(FILES "${modbus_src}/c/modbus.h" DESTINATION ${OMC_INCLUDE_DIR})
 
   install(TARGETS modbus
     LIBRARY DESTINATION ${OMC_LIBRARY_DIR}

--- a/lib/modcount/CMakeLists.txt
+++ b/lib/modcount/CMakeLists.txt
@@ -12,7 +12,7 @@ if(USE_OMC)
     DESTINATION "${OMC_MOD_LIB_DIR}/${MODELICA_SERVICES_LIBRARY}")
 
   # Install library header
-  #install(FILES "${modcount_src}/c/modcount.h" DESTINATION ${OMC_INCLUDE_DIR})
+  install(FILES "${modcount_src}/c/modcount.h" DESTINATION ${OMC_INCLUDE_DIR})
 
   install(TARGETS modcount  
     LIBRARY DESTINATION ${OMC_LIBRARY_DIR}


### PR DESCRIPTION
The find script for omc was upated so it works now and some hacks to the cmakelist.txt install were undone so that the created cpack -G DEB debian package works again on ubuntu. This is useful for debugging/ development.