### PR TITLE
Added annotation to fix default name of m3d_control.

### DIFF
--- a/lib/mod3d/src/modelica/Modelica3D 3.2.1/package.mo
+++ b/lib/mod3d/src/modelica/Modelica3D 3.2.1/package.mo
@@ -28,6 +28,10 @@ package Modelica3D
     when terminal() then
       if autostop then stop(conn, context); end if;
     end when;
+  annotation (
+    defaultComponentName="m3d_control",
+    defaultComponentPrefixes="inner",
+    missingInnerMessage="No \"m3d_control\" component is defined.");
   end Controller;
 
   function objectId


### PR DESCRIPTION
In OMEdit this makes drag and drop work with proper name and inner for m3d_control.